### PR TITLE
FIX: CreateBasket component works with mock API

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,16 +10,9 @@ const Basket = () => <></>;
 
 function App() {
   const [baskets, setBaskets] = useState<Array<string>>([]);
-  const [generatedName, setGeneratedName] = useState<string>("");
 
   useEffect(() => {
-    apiService.getBaskets().then((mockBaskets) => {
-      setBaskets(mockBaskets);
-    });
-
-    apiService.generateName().then((basketName) => {
-      setGeneratedName(basketName);
-    });
+    apiService.getBaskets().then((baskets) => setBaskets(baskets));
   }, []);
 
   return (
@@ -28,7 +21,7 @@ function App() {
       <Baskets baskets={baskets} />
 
       <Routes>
-        <Route path="/" element={<CreateBasket basketName={generatedName} />} />
+        <Route path="/" element={<CreateBasket setBaskets={setBaskets} />} />
         <Route path="baskets">
           <Route path=":basketName" element={<Basket />} />
         </Route>

--- a/frontend/src/components/CreateBasket/CreateBasket.tsx
+++ b/frontend/src/components/CreateBasket/CreateBasket.tsx
@@ -15,7 +15,7 @@ const CreateBasket = ({ setBaskets }: CreateBasketProps) => {
       .then((generatedName) => setBasketName(generatedName));
   }, []);
 
-  // TODO: refactored error handling after `utils.handleAPIError` is on main
+  // TODO: We should refactore error handling after `utils.handleAPIError` is on main
   // TODO: message notification should be handled in react, if we want it
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/frontend/src/components/CreateBasket/CreateBasket.tsx
+++ b/frontend/src/components/CreateBasket/CreateBasket.tsx
@@ -15,7 +15,7 @@ const CreateBasket = ({ setBaskets }: CreateBasketProps) => {
       .then((generatedName) => setBasketName(generatedName));
   }, []);
 
-  // TODO: We should refactore error handling after `utils.handleAPIError` is on main
+  // TODO: We should refactor error handling after `utils.handleAPIError` is on main
   // TODO: message notification should be handled in react, if we want it
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/frontend/src/components/CreateBasket/CreateBasket.tsx
+++ b/frontend/src/components/CreateBasket/CreateBasket.tsx
@@ -1,20 +1,60 @@
+import { useState, useEffect } from "react";
 import "./CreateBasket.css";
+import apiService from "../../services/requestBinAPI";
 
 interface CreateBasketProps {
-  basketName: string;
+  setBaskets: React.Dispatch<React.SetStateAction<Array<string>>>;
 }
 
-const CreateBasket = ({ basketName }: CreateBasketProps) => {
+const CreateBasket = ({ setBaskets }: CreateBasketProps) => {
+  const [basketName, setBasketName] = useState<string>("");
+
+  useEffect(() => {
+    apiService
+      .generateName()
+      .then((generatedName) => setBasketName(generatedName));
+  }, []);
+
+  // TODO: refactored error handling after `utils.handleAPIError` is on main
+  // TODO: message notification should be handled in react, if we want it
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const message = await apiService.createBasket(basketName);
+      // Refetch all baskets.
+      // - we don't add the new basket name to our state because
+      //   the server does not return the basketName value so we
+      //   have no way of knowing whether our state aligns with
+      //   the server's state.
+
+      const baskets = await apiService.getBaskets();
+      setBaskets(baskets);
+      alert(message);
+    } catch (error: unknown) {
+      alert(error);
+    }
+  };
+
+  const handleBasketNameChange = (event: React.FormEvent<HTMLInputElement>) => {
+    setBasketName(event.currentTarget.value);
+  };
+
   return (
     <div>
       <h1>New Basket</h1>
       <p>Create a basket to collect and inspect HTTP Requests</p>
-      <form>
+
+      <form onSubmit={handleSubmit}>
         <div>
           <label htmlFor="createBasket">placeholder.com/</label>
-          <input type="text" id="createBasket" value={basketName} />
+          <input
+            type="text"
+            id="new-basket-name"
+            value={basketName}
+            onChange={handleBasketNameChange}
+          />
           <button type="submit" className="">
-            Button
+            Create
           </button>
         </div>
       </form>


### PR DESCRIPTION
CreateBasket component now works with mock API
- basket name state has been moved to that component
- currently refetches all baskets on submit
- error handling is blocked by `utils.ts` (pull request #30)
- currently uses `alert` for notifications - we should handle this in react.