### PR TITLE
Baskets component width fix

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,10 @@ function App() {
           >
             <Stack
               direction={{ sm: "row", xs: "column" }}
-              sx={{ justifyContent: "space-between" }}
+              sx={{
+                justifyContent: "space-between",
+                alignItems: { sm: "flex-start", xs: "stretch" },
+              }}
               spacing={2}
             >
               <Routes>

--- a/frontend/src/components/Baskets/Baskets.tsx
+++ b/frontend/src/components/Baskets/Baskets.tsx
@@ -2,7 +2,6 @@ import { Link } from "react-router";
 import { Paper, List, ListItem, ListItemIcon, Typography } from "@mui/material";
 import { Archive } from "@mui/icons-material";
 
-
 interface BasketsProps {
   baskets: Array<string>;
 }
@@ -15,8 +14,8 @@ const Baskets = ({ baskets }: BasketsProps) => {
     <Paper
       elevation={4}
       sx={{
-        padding: 2,
-        width: 200,
+        flexGrow: 0,
+        padding: 3,
         color: "primary.contrastText",
         boxSizing: "border-box",
         borderRadius: 1,

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -8,6 +8,15 @@ const theme = createTheme({
       main: "#80cbc4",
     },
   },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 500,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
Following issues have been fixed:
- `Baskets` component was not filling the entire width when forced below the basket for smaller screen sizes.
- Deletion of the `Baskets.css` file caused the `Baskets` component to have fixed height in `sm` breakpoint due to the parent `Stack` having `alignItems: "stretch"` by default.