### PR TITLE
Basket component mui migration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <BrowserRouter>
-        <Container maxWidth="md" sx={{ minWidth: "350px" }}>
+        <Container maxWidth="xl" sx={{ minWidth: "350px" }}>
           <CssBaseline />
           <Nav />
           <Box
@@ -34,9 +34,12 @@ function App() {
             }}
           >
             <Stack
-              direction={{ sm: "row", xs: "column" }}
-              sx={{ justifyContent: "space-between" }}
-              spacing={2}
+              direction="row"
+              sx={{
+                gap: 3,
+                flexWrap: "wrap",
+                justifyContent: "space-between",
+              }}
             >
               <Routes>
                 <Route

--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -37,6 +37,7 @@ const Basket = () => {
     <Paper
       elevation={4}
       sx={{
+        maxWidth: "100%",
         flexGrow: 1,
         padding: 2,
       }}

--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from "react";
 import { useParams } from "react-router";
 import type { Request as RequestType } from "../../types";
-import Request from "../../components/Request";
 import apiService from "../../services/requestBinAPI";
 import { handleAPIError } from "../../utils";
+import RequestList from "../RequestList";
+import { Paper, Container, Stack, Divider, Typography } from "@mui/material";
 
 const Basket = () => {
   const basketName = useParams().basketName ?? "";
@@ -24,38 +25,35 @@ const Basket = () => {
   }, [basketName]);
 
   return (
-    <>
-      <div className="basket">
-        {requests.length === 0 ? (
-          <h2>
+    <Paper
+      elevation={4}
+      sx={{
+        flexGrow: 1,
+        padding: 2,
+      }}
+    >
+      <Container>
+        <Stack
+          direction="row"
+          sx={{
+            flexWrap: "wrap",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Typography variant="h4" sx={{ paddingRight: 3 }}>
             Basket: <code>/{basketName}</code>
-          </h2>
-        ) : (
-          <>
-            <h2>
-              Basket: <code>/{basketName}</code>
-            </h2>
-            <h3># of requests {requests.length}</h3>
-          </>
-        )}
+          </Typography>
+          <Divider />
+          <Typography variant="subtitle2">
+            {requests.length} requests
+          </Typography>
+        </Stack>
 
-        <section className="requests">
-          {requests.length === 0 ? (
-            <div className="emptyBasket">
-              <h3>Empty Basket!</h3>
-              <p>
-                This basket is empty, send requests to url/{basketName} and they
-                will appear here.
-              </p>
-            </div>
-          ) : (
-            requests.map((request, i) => (
-              <Request key={i} {...request} basketName={basketName} />
-            ))
-          )}
-        </section>
-      </div>
-    </>
+        <Divider />
+        <RequestList basketName={basketName} requests={requests} />
+      </Container>
+    </Paper>
   );
 };
 

--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -4,7 +4,16 @@ import type { Request as RequestType } from "../../types";
 import apiService from "../../services/requestBinAPI";
 import { handleAPIError } from "../../utils";
 import RequestList from "../RequestList";
-import { Paper, Container, Stack, Divider, Typography } from "@mui/material";
+import {
+  Button,
+  Paper,
+  Container,
+  Stack,
+  Divider,
+  Typography,
+  Tooltip,
+} from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 const Basket = () => {
   const basketName = useParams().basketName ?? "";
@@ -44,7 +53,21 @@ const Basket = () => {
           <Typography variant="h4" sx={{ paddingRight: 3 }}>
             Basket: <code>/{basketName}</code>
           </Typography>
-          <Divider />
+
+          <Tooltip arrow title="Copy basket link" placement="top">
+            <Button
+              sx={{ flexGrow: 0 }}
+              onClick={async () => {
+                // TODO: fix link
+                await navigator.clipboard.writeText(
+                  `https://placeholder.com/hook/${basketName}`,
+                );
+              }}
+            >
+              <ContentCopyIcon />
+            </Button>
+          </Tooltip>
+
           <Typography variant="subtitle2">
             {requests.length} requests
           </Typography>

--- a/frontend/src/components/Baskets/Baskets.tsx
+++ b/frontend/src/components/Baskets/Baskets.tsx
@@ -2,7 +2,6 @@ import { Link } from "react-router";
 import { Paper, List, ListItem, ListItemIcon, Typography } from "@mui/material";
 import { Archive } from "@mui/icons-material";
 
-
 interface BasketsProps {
   baskets: Array<string>;
 }

--- a/frontend/src/components/EmptyBasketContent/EmptyBasketContent.tsx
+++ b/frontend/src/components/EmptyBasketContent/EmptyBasketContent.tsx
@@ -1,0 +1,11 @@
+const EmptyBasketContent = ({ basketName }: { basketName: string }) => (
+  <div className="emptyBasket">
+    <h3>Empty Basket!</h3>
+    <p>
+      This basket is empty, send requests to{" "}
+      <code>placeholder.com/hook/{basketName}</code> and they will appear here.
+    </p>
+  </div>
+);
+
+export default EmptyBasketContent;

--- a/frontend/src/components/EmptyBasketContent/index.ts
+++ b/frontend/src/components/EmptyBasketContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EmptyBasketContent";

--- a/frontend/src/components/Request/Request.tsx
+++ b/frontend/src/components/Request/Request.tsx
@@ -1,6 +1,17 @@
 import type { Request as RequestProps } from "../../types";
 import { JSONTree } from "react-json-tree";
 import { useState } from "react";
+import {
+  Box,
+  Stack,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Switch,
+  Tooltip,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const Request = ({
   basketName,
@@ -11,36 +22,76 @@ const Request = ({
   requestBody,
 }: RequestProps & { basketName: string }) => {
   const [showJSON, setShowJSON] = useState(false);
-
-  const showJSONToggle = () => {
-    setShowJSON(!showJSON);
-  };
-
-  // console.log(basketName);
+  const isJSON: boolean = requestBodyContentType
+    .trim()
+    .toLowerCase()
+    .endsWith("json");
 
   return (
-    <div className="request">
-      <section>
-        <h4>{method}</h4>
-        <time>{sentAt}</time>
-      </section>
-      <section>
-        <span>{basketName}</span>
-        <details>
-          <summary>Headers</summary>
-          {headers}
-        </details>
-        <details>
-          <summary>Body</summary>
-          {requestBodyContentType === "application/json" && showJSON ? (
-            <JSONTree data={JSON.parse(requestBody)} />
-          ) : (
-            requestBody
-          )}
-          <button onClick={showJSONToggle}>JSONify</button>
-        </details>
-      </section>
-    </div>
+    <Stack direction="row">
+      <Box>
+        <Typography variant="h5">{method}</Typography>
+        <Typography
+          component="time"
+          variant="caption"
+          sx={{ wordWrap: "break-all" }}
+        >
+          {sentAt}
+        </Typography>
+
+        {isJSON && (
+          <Tooltip arrow title="Format JSON" placement="right">
+            <Switch
+              checked={showJSON}
+              onChange={(e) => {
+                setShowJSON(e.target.checked);
+              }}
+            />
+          </Tooltip>
+        )}
+      </Box>
+
+      <Box>
+        <Accordion>
+          <AccordionDetails>
+            <Typography component="code">
+              placeholder.com/hook/{basketName}
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            Headers
+          </AccordionSummary>
+          <AccordionDetails>
+            {headers.split("\n").map((headerText) => {
+              return <Typography variant="body1">{headerText}</Typography>;
+            })}
+          </AccordionDetails>
+        </Accordion>
+
+        <Accordion>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            Body
+          </AccordionSummary>
+
+          <AccordionDetails>
+            {isJSON && showJSON ? (
+              <JSONTree data={JSON.parse(requestBody)} />
+            ) : (
+              <Box>
+                <Typography
+                  component="pre"
+                  sx={{ wordBreak: "break-all", textWrap: "wrap" }}
+                >
+                  {requestBody}
+                </Typography>
+              </Box>
+            )}
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+    </Stack>
   );
 };
 

--- a/frontend/src/components/Request/Request.tsx
+++ b/frontend/src/components/Request/Request.tsx
@@ -28,7 +28,14 @@ const Request = ({
     .endsWith("json");
 
   return (
-    <Stack direction="row">
+    <Stack
+      direction="row"
+      sx={{
+        gap: 3,
+        flexWrap: "wrap",
+        justifyContent: "space-between",
+      }}
+    >
       <Box>
         <Typography variant="h5">{method}</Typography>
         <Typography
@@ -55,7 +62,7 @@ const Request = ({
         <Accordion>
           <AccordionDetails>
             <Typography component="code">
-              placeholder.com/hook/{basketName}
+              PATH: placeholder.com/hook/{basketName}
             </Typography>
           </AccordionDetails>
         </Accordion>
@@ -65,7 +72,14 @@ const Request = ({
           </AccordionSummary>
           <AccordionDetails>
             {headers.split("\n").map((headerText) => {
-              return <Typography variant="body1">{headerText}</Typography>;
+              return (
+                <Typography
+                  variant="body1"
+                  sx={{ wordBreak: "break-all", textWrap: "wrap" }}
+                >
+                  {headerText}
+                </Typography>
+              );
             })}
           </AccordionDetails>
         </Accordion>

--- a/frontend/src/components/RequestList/RequestList.tsx
+++ b/frontend/src/components/RequestList/RequestList.tsx
@@ -1,0 +1,27 @@
+import type { Request as RequestType } from "../../types";
+import Request from "../../components/Request";
+import EmptyBasketContent from "../EmptyBasketContent";
+import { List, ListItem } from "@mui/material";
+
+interface RequestListProps {
+  basketName: string;
+  requests: Array<RequestType>;
+}
+
+const RequestList = ({ basketName, requests }: RequestListProps) => {
+  return (
+    <List>
+      {requests.length ? (
+        requests.map((request, i) => (
+          <ListItem key={i}>
+            <Request {...request} basketName={basketName} />
+          </ListItem>
+        ))
+      ) : (
+        <EmptyBasketContent basketName={basketName} />
+      )}
+    </List>
+  );
+};
+
+export default RequestList;

--- a/frontend/src/components/RequestList/index.ts
+++ b/frontend/src/components/RequestList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RequestList";


### PR DESCRIPTION
Opening this PR for now, since it technically works, but this definitely needs some more touch up.
- The auto width sizing needs to be fixed / breakpoints for some components may need to be adjusted.
- Consider using a drawer for the My Baskets component to save screen space.
- Also I could not get the raw header/body data to render as "code".

- I refactored `RequestList` and `EmptyBasketContent` out into separate components to keep each React component simple.
- The `Request` component is getting too big, so that will probably have to be refactored too.

