### PR TITLE
Basket url copy button

### DIFF
--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -12,12 +12,14 @@ import {
   Divider,
   Typography,
   Tooltip,
+  Snackbar,
 } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 const Basket = () => {
   const basketName = useParams().basketName ?? "";
   const [requests, setRequests] = useState<Array<RequestType>>([]);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
 
   const populateBasket = (basketName: string) => {
     try {
@@ -34,7 +36,7 @@ const Basket = () => {
     await navigator.clipboard.writeText(
       `https://placeholder.com/hook/${basketName}`,
     );
-    // TODO: add confirmation toast
+    setSnackbarOpen(true);
   };
 
   useEffect(() => {
@@ -50,6 +52,14 @@ const Basket = () => {
         padding: 2,
       }}
     >
+      <Snackbar
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackbarOpen(false)}
+        message="Basket url copied to clipboard."
+      />
+
       <Container>
         <Stack
           direction="row"

--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -63,10 +63,10 @@ const Basket = () => {
             Basket:
             <Tooltip arrow title="Copy basket link" placement="top">
               <Button
-                sx={{ flexGrow: 0, color: "primary.dark" }}
+                sx={{ flexGrow: 0, color: "info.main" }}
                 onClick={handleCopyLinkButtonClick}
               >
-                <Typography variant="h5" sx={{ paddingRight: 3 }}>
+                <Typography variant="h5" sx={{ paddingRight: 1 }}>
                   <code>/{basketName}</code>
                 </Typography>
                 <ContentCopyIcon fontSize="small" />

--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -29,6 +29,14 @@ const Basket = () => {
     }
   };
 
+  const handleCopyLinkButtonClick = async () => {
+    // TODO: fix link
+    await navigator.clipboard.writeText(
+      `https://placeholder.com/hook/${basketName}`,
+    );
+    // TODO: add confirmation toast
+  };
+
   useEffect(() => {
     populateBasket(basketName);
   }, [basketName]);
@@ -51,23 +59,20 @@ const Basket = () => {
             alignItems: "center",
           }}
         >
-          <Typography variant="h4" sx={{ paddingRight: 3 }}>
-            Basket: <code>/{basketName}</code>
+          <Typography variant="h4">
+            Basket:
+            <Tooltip arrow title="Copy basket link" placement="top">
+              <Button
+                sx={{ flexGrow: 0, color: "primary.dark" }}
+                onClick={handleCopyLinkButtonClick}
+              >
+                <Typography variant="h5" sx={{ paddingRight: 3 }}>
+                  <code>/{basketName}</code>
+                </Typography>
+                <ContentCopyIcon fontSize="small" />
+              </Button>
+            </Tooltip>
           </Typography>
-
-          <Tooltip arrow title="Copy basket link" placement="top">
-            <Button
-              sx={{ flexGrow: 0 }}
-              onClick={async () => {
-                // TODO: fix link
-                await navigator.clipboard.writeText(
-                  `https://placeholder.com/hook/${basketName}`,
-                );
-              }}
-            >
-              <ContentCopyIcon />
-            </Button>
-          </Tooltip>
 
           <Typography variant="subtitle2">
             {requests.length} requests


### PR DESCRIPTION
Fixed some styling issues with the copy url button
- it now integrates with the url endpoint text, instead of floating to the right.
- it now triggers a 3s toast, which is dismissable by clicking anywhere.