### PR TITLE
style: updated token function names

### DIFF
--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -3,8 +3,8 @@ import pool from "../controllers/postgresql";
 import { QueryResult } from "pg";
 import {
   isBasketNameUnique,
-  generate_random_string,
-  generate_token,
+  generateRandomString,
+  generateToken,
   storeToken,
   addNewBasket,
 } from "../utils";
@@ -27,24 +27,29 @@ router.get("/baskets", async (_req: Request, res: Response) => {
   }
 });
 
-
 router.get("/generate_name", async (_req: Request, res: Response) => {
   let basketName: string = "";
 
   do {
-    basketName = generate_random_string().substring(2, 9);
+    basketName = generateRandomString().substring(2, 9);
   } while ((await isBasketNameUnique(basketName)) === false);
 
   res.status(200).json({ basketName });
 });
 
-router.get("/generate_token", async (_req: Request, res: Response) => {
-  let token: string = await generate_token();
-  await storeToken(token);
+router.get("/generate_token", async (req: Request, res: Response) => {
+  const basketName = req.query.name;
+
+  if (typeof basketName !== "string") {
+    res.status(422).send("missing basket name");
+    return;
+  }
+
+  let token: string = await generateToken();
+  await storeToken(token, basketName);
 
   res.status(200).json({ token });
 });
-
 
 router.post("/baskets/:name", async (req: Request, res: Response) => {
   const basketName = req.params.name;

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -5,18 +5,18 @@ import type { Token, Basket, Request } from "./types";
 import { QueryResult } from "pg";
 import mongoose from "mongoose";
 
-export function generate_random_string() {
+export function generateRandomString() {
   return Math.random().toString(36).substring(2);
 }
 
-export async function generate_token(): Promise<string> {
+export async function generateToken(): Promise<string> {
   let token: string = "";
-  const query: string = "SELECT * FROM tokens WHERE token_value = ($1)";
+  const query: string = "SELECT token FROM baskets WHERE token = ($1)";
   let result: QueryResult<Token>;
   try {
     do {
       const segments: string[] = Array.from({ length: 3 }, () =>
-        generate_random_string()
+        generateRandomString()
       );
       token = segments.join("");
 
@@ -29,12 +29,18 @@ export async function generate_token(): Promise<string> {
   }
 }
 
-export async function storeToken(token: string): Promise<Token> {
+export async function storeToken(
+  token: string,
+  basketName: string
+): Promise<Token> {
   const query: string =
-    "INSERT INTO tokens (token_value) VALUES ($1) RETURNING *";
+    "UPDATE baskets SET token = ($1) WHERE name = $2 RETURNING *";
 
   try {
-    const result: QueryResult<Token> = await pool.query(query, [token]);
+    const result: QueryResult<Token> = await pool.query(query, [
+      token,
+      basketName,
+    ]);
     console.log("Inserted token:", result.rows[0]);
     return result.rows[0];
   } catch (err) {


### PR DESCRIPTION
backend/src/utils.ts
- renamed generate_random_string -> generateRandomString
- renamed generate_token -> generateToken
- updated SQL queries to work with the new schema for generateToken and storeToken


backend/src/routes/api.ts
- updated references to generateToken & generateRandomString
- updated /generate_token route
     -> it now requires the basket name as a querystring param (i.e. "/generate_token?name=qwerty") This is a hotfix till we get around to dealing with tokens