### PR TITLE
Local storage hook

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS baskets (
   name varchar(255) PRIMARY KEY,
+  created_at timestamp DEFAULT now() NOT NULL,
   token varchar(255)
 );
 

--- a/backend/src/controllers/postgresql.ts
+++ b/backend/src/controllers/postgresql.ts
@@ -118,7 +118,7 @@ class PostgresClient {
           headers,
           bodyMongoId,
         },
-        err
+        err,
       );
       throw new Error("PostgreSQL: Failed to store request");
     }
@@ -135,7 +135,7 @@ class PostgresClient {
       console.error(
         "PostgreSQL: Error getting basket request body IDs for basket: ",
         basketName,
-        error
+        error,
       );
       throw new Error("PostgreSQL: Failed to get basket request body IDs");
     }
@@ -149,13 +149,13 @@ class PostgresClient {
         "PostgreSQL: ",
         result.rowCount,
         " deleted requests for basket",
-        basketName
+        basketName,
       );
       return true;
     } catch (error) {
       console.error(
         `PostgreSQL: Error deleting requests bodies for basket: ${basketName}:`,
-        error
+        error,
       );
       return false;
     }
@@ -181,7 +181,7 @@ class PostgresClient {
   public async getValidBaskets(basketNames: string[]): Promise<string[]> {
     let placeHolder = basketNames.map((_, idx) => `$${idx + 1}`).join(", ");
 
-    const query = `SELECT name FROM baskets WHERE name = ANY(ARRAY[${placeHolder}])`;
+    const query = `SELECT name FROM baskets WHERE name = ANY(ARRAY[${placeHolder}]) ORDER BY created_at DESC;`;
 
     try {
       const result = await this.pool.query(query, basketNames);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { BrowserRouter, Routes, Route } from "react-router";
 import apiService from "./services/apiService.ts";
-import { handleAPIError, setErrorNotifier } from "./utils.ts";
+import { handleAPIError, setErrorNotifier, removeBasket } from "./utils.ts";
+import useLocalStorageState from "./hooks/useLocalStorageState";
 import { useNotifications } from "@toolpad/core/useNotifications";
 import Container from "@mui/material/Container";
 import Box from "@mui/material/Box";
@@ -17,40 +18,33 @@ import CreateBasket from "./components/CreateBasket";
 import MyBasketsFab from "./components/MyBasketsFab";
 
 function App() {
-  const [baskets, setBaskets] = useState<Array<string>>([]);
+  const baskets = useLocalStorageState();
   const [drawerState, setDrawerState] = useState(false);
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const notifications = useNotifications();
   const originURL = window.location.origin;
 
-  const getBaskets = () => {
-    const baskets = Object.keys(localStorage);
-    setBaskets(baskets);
-  };
-
-  const validateBaskets = async () => {
+  const validateBaskets = useCallback(async () => {
     try {
-      const localBaskets = Object.keys(localStorage);
-      const validBaskets = await apiService.getValidBaskets(localBaskets);
+      const validBaskets = await apiService.getValidBaskets(baskets);
 
-      localBaskets.forEach((key) => {
+      baskets.forEach((key) => {
         if (!validBaskets.includes(key)) {
-          localStorage.removeItem(key);
+          removeBasket(key);
         }
       });
     } catch (error: unknown) {
       handleAPIError(error, "Your baskets could not be found.");
     }
-  };
+  }, [baskets]);
 
   // load initial state
   useEffect(() => {
     validateBaskets();
-    getBaskets();
     setErrorNotifier((message) =>
       notifications.show(message, { key: message, severity: "error" }),
     );
-  }, [notifications]);
+  }, [notifications, validateBaskets]);
 
   return (
     <ThemeProvider theme={theme}>
@@ -79,19 +73,12 @@ function App() {
               <Routes>
                 <Route
                   path="/"
-                  element={
-                    <CreateBasket
-                      originURL={originURL}
-                      setBaskets={setBaskets}
-                    />
-                  }
+                  element={<CreateBasket originURL={originURL} />}
                 />
                 <Route path="baskets">
                   <Route
                     path=":basketName"
-                    element={
-                      <Basket originURL={originURL} getBaskets={getBaskets} />
-                    }
+                    element={<Basket originURL={originURL} />}
                   />
                 </Route>
               </Routes>

--- a/frontend/src/components/Basket/Basket.tsx
+++ b/frontend/src/components/Basket/Basket.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router";
 import { useNotifications } from "@toolpad/core/useNotifications";
 import type { Request as RequestType } from "../../types";
 import apiService from "../../services/apiService";
-import { handleAPIError } from "../../utils";
+import { handleAPIError, removeBasket } from "../../utils";
 import DialogComponent from "../Dialog";
 import RequestList from "../RequestList";
 import Grid from "@mui/material/Grid";
@@ -24,10 +24,9 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 
 interface BasketProps {
   originURL: string;
-  getBaskets: () => void;
 }
 
-const Basket = ({ originURL, getBaskets }: BasketProps) => {
+const Basket = ({ originURL }: BasketProps) => {
   const POLLING_INTERVAL = 1000; // poll every 1 second
   const basketName = useParams().basketName ?? "";
   const notifications = useNotifications();
@@ -57,8 +56,7 @@ const Basket = ({ originURL, getBaskets }: BasketProps) => {
   const handleDeleteBasketButtonClick = async () => {
     try {
       await apiService.deleteBasket(basketName);
-      localStorage.removeItem(basketName);
-      getBaskets();
+      removeBasket(basketName);
       navigate("/");
 
       notifications.show(`Deleted basket /${basketName}`, {

--- a/frontend/src/components/CreateBasket/CreateBasket.tsx
+++ b/frontend/src/components/CreateBasket/CreateBasket.tsx
@@ -2,16 +2,15 @@ import { useState, useEffect } from "react";
 import type { ChangeEvent } from "react";
 import { useNavigate } from "react-router";
 import apiService from "../../services/apiService";
-import { handleAPIError } from "../../utils";
+import { handleAPIError, addBasket } from "../../utils";
 import { Paper, Typography, Stack, TextField, Button } from "@mui/material";
 import { useNotifications } from "@toolpad/core/useNotifications";
 
 interface CreateBasketProps {
   originURL: string;
-  setBaskets: React.Dispatch<React.SetStateAction<Array<string>>>;
 }
 
-const CreateBasket = ({ originURL, setBaskets }: CreateBasketProps) => {
+const CreateBasket = ({ originURL }: CreateBasketProps) => {
   const [basketName, setBasketName] = useState<string>("");
   const notifications = useNotifications();
 
@@ -32,8 +31,7 @@ const CreateBasket = ({ originURL, setBaskets }: CreateBasketProps) => {
       const verifiedName = await apiService.createBasket(basketName);
       const generatedToken = await apiService.getToken(basketName);
 
-      localStorage.setItem(`${verifiedName}`, generatedToken);
-      setBaskets((baskets) => baskets.concat(verifiedName));
+      addBasket(`${verifiedName}`, generatedToken);
       notifications.show(`${verifiedName} basket was created!`, {
         severity: "success",
         autoHideDuration: 3000,

--- a/frontend/src/components/MyBaskets/MyBaskets.tsx
+++ b/frontend/src/components/MyBaskets/MyBaskets.tsx
@@ -31,7 +31,7 @@ const MyBaskets = ({ baskets, drawerState, setDrawerState }: BasketsProps) => {
         <ListSubheader>My Baskets</ListSubheader>
         <Divider />
 
-        {baskets.toReversed().map((basketName) => (
+        {baskets.map((basketName) => (
           <MenuItem
             key={basketName}
             component={NavLink}

--- a/frontend/src/hooks/useLocalStorageState/index.ts
+++ b/frontend/src/hooks/useLocalStorageState/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useLocalStorageState";

--- a/frontend/src/hooks/useLocalStorageState/useLocalStorageState.ts
+++ b/frontend/src/hooks/useLocalStorageState/useLocalStorageState.ts
@@ -1,0 +1,50 @@
+import { useSyncExternalStore, useCallback, useRef } from "react";
+
+const useLocalStorageState = () => {
+  const snapshotCache = useRef<Array<string>>([]);
+
+  const getSnapshot = useCallback(() => {
+    const keys = Array.from(
+      { length: window.localStorage.length },
+      (_, i) => window.localStorage.key(i) as string,
+    );
+
+    if (JSON.stringify(keys) !== JSON.stringify(snapshotCache.current)) {
+      snapshotCache.current = keys;
+    }
+
+    console.log(`From getSnapshot: ${snapshotCache.current}`);
+    return snapshotCache.current;
+  }, []);
+
+  const subscribe = useCallback((callback: () => void) => {
+    window.addEventListener("storage", callback);
+
+    return () => {
+      window.removeEventListener("storage", callback);
+    };
+  }, []);
+
+  const keys = useSyncExternalStore(subscribe, getSnapshot);
+
+  // patch methods so localStorage mutations trigger StorageEvent on current tab
+  if (typeof window !== "undefined") {
+    const _setItem = window.localStorage.setItem;
+    window.localStorage.setItem = function setItem(key, newValue) {
+      const result = _setItem.call(this, key, newValue);
+      window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+      return result;
+    };
+
+    const _removeItem = window.localStorage.removeItem;
+    window.localStorage.removeItem = function removeItem(key) {
+      const result = _removeItem.call(this, key);
+      window.dispatchEvent(new StorageEvent("storage", { key }));
+      return result;
+    };
+  }
+
+  return keys;
+};
+
+export default useLocalStorageState;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -42,3 +42,20 @@ export const hasContentTypeJSON = (headers: string) => {
     }
   });
 };
+
+export const addBasket = (basketName: string, token: string) => {
+  window.localStorage.setItem(basketName, token);
+  window.dispatchEvent(
+    new StorageEvent("storage", { key: basketName, newValue: token }),
+  );
+};
+
+export const removeBasket = (basketName: string) => {
+  window.localStorage.removeItem(basketName);
+  window.dispatchEvent(new StorageEvent("storage", { key: basketName }));
+};
+
+export const clearBaskets = () => {
+  window.localStorage.clear();
+  window.dispatchEvent(new StorageEvent("storage"));
+};


### PR DESCRIPTION
- `useSyncExternalStore` implementation to sync state with browser local
storage state
- My Baskets now preserve sort order.
  - To accomplish this, I added a `created_at` row in the schema for baskets and modified the
validate baskets method in `postgresql.ts` to sort by timestamp.
  - This has to be done on the backend because local storage does not preserve insertion order.
- *NOTE*: because I modified the schema, you will have to re-initialise the database.
- Local state is now verified via api call on every basket create and
delete operation.