### PR TITLE
enhance: added PG init to scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "tsc": "tsc",
     "dev": "ts-node-dev ./src/main.ts",
     "start": "node build/main.js",
-    "db-init": "createdb requestbin && psql -d requestbin < schema.sql",
+    "db-init": "ts-node pgDatabaseInit.ts",
     "mock": "USE_MOCK_API=true ts-node-dev ./src/main.ts",
     "build:backend": "npm install && npm run tsc",
     "build:frontend": "rm -rf dist && cd ../frontend && npm install && npm run build && cp -r dist ../backend",


### PR DESCRIPTION
I incorporated the DB initialiser by adding it to the build script.
I think this is the best option because the script will error if run when the DB already exists. (so for example if we use PM2 and had it incorporated into the controller the program would crash anytime it restarts after the initial startup)

Also, you can't make a `constructor` function async so it was getting a little messy to add to the controller.